### PR TITLE
Added relative link to the Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # zfs-ha
 # 
+[Please see the Wiki for more information](../../wiki)


### PR DESCRIPTION
The actual content is in the Wiki so most people stumbling upon this repo via the github search will just find an almost blank readme.md.
